### PR TITLE
even older little ones need mommy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,22 @@ version = 3
 
 [[package]]
 name = "cargo-mommy"
-version = "0.1.0"
+version = "0.1.1"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,12 @@ description = "Mommy's here to support you when running cargo~"
 repository = "https://github.com/Gankra/cargo-mommy"
 license = "MIT OR Apache-2.0"
 name = "cargo-mommy"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[build-dependencies]
+rustc_version = "0.4.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+use rustc_version::Version;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let version = rustc_version::version().unwrap();
+
+    // How annoying it is to check rust versions! Why do we do this?
+    // The stable ExitCode API is locked behind `feature(process_exitcode_placeholder)`
+    // and Termination behind `feature(termination_trait_lib)` prior to 1.61.0.
+    // These provide nice functionality, but keep legacy developers away from mommy.
+    // We provide a "compat" version of the program that's basically the same,
+    // but avoids using any ExitCode functionality.
+    if version < Version::new(1, 61, 0) {
+        println!("cargo:rustc-cfg=compat");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,19 @@
+#[cfg(not(compat))]
 use std::process::ExitCode;
 
+#[cfg(not(compat))]
 fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
+    // `code` can be a negative value, so the cast can wrap
+    main_impl().map(|code| (code as u8).into())
+}
+
+#[cfg(compat)]
+fn main() {
+    std::process::exit(main_impl().unwrap())
+}
+
+// `main`, but without the need to return a value that implements `Termination`
+fn main_impl() -> Result<i32, Box<dyn std::error::Error>> {
     let cargo = std::env::var("CARGO")?;
     let mommys_little = std::env::var("CARGO_MOMMYS_LITTLE").unwrap_or_else(|_| "girl".to_owned());
     let mut arg_iter = std::env::args();
@@ -17,7 +30,7 @@ fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
         eprintln!("Mommy knows her little {} can do better~ ❤️", mommys_little);
     }
     eprintln!("\x1b[0m");
-    Ok(ExitCode::from(status.code().unwrap_or(-1) as u8))
+    Ok(status.code().unwrap_or(-1))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I love how simple and silly this project is!  Some legacy codebases can't use `ExitCode` as a stable API, so they have trouble working with this extension.  Here's an attempt at supporting those poor developers.