### PR TITLE
compile-time responses deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,7 @@ edition = "2021"
 
 [dependencies]
 rand = { version = "0.8.5" }
+
+[build-dependencies]
 serde = { version = "1.0.151", features = ["derive"] }
 serde_json = "1.0.91"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,28 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+const RESPONSES: &str = include_str!("./responses.json");
+
+#[derive(serde::Deserialize)]
+struct Responses {
+    positive: Vec<String>,
+    negative: Vec<String>,
+}
+
+fn main() {
+    let out_dir = &env::var("OUT_DIR").unwrap();
+    let responses: Responses = serde_json::from_str(RESPONSES).unwrap();
+    let dest_path = Path::new(out_dir).join("responses.rs");
+
+    fs::write(
+        dest_path,
+        format!(
+            "const POSITIVE_RESPONSES: &[&str] = &{:?};\nconst NEGATIVE_RESPONSES: &[&str] = &{:?};",
+            responses.positive, responses.negative
+        ),
+    )
+    .unwrap();
+
+    println!("cargo:rerun-if-changed=responses.json");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,8 @@ fn select_response(response_type: ResponseType) -> String {
 
     // Choose what mommy will say~
     let response = match response_type {
-        ResponseType::Positive => &POSITIVE_RESPONSES,
-        ResponseType::Negative => &NEGATIVE_RESPONSES,
+        ResponseType::Positive => POSITIVE_RESPONSES,
+        ResponseType::Negative => NEGATIVE_RESPONSES,
     }
     .choose(&mut rng)
     .expect("non-zero amount of responses");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::let_and_return)]
 
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
-use serde::Deserialize;
 
-const RESPONSES: &str = include_str!("../responses.json");
+include!(concat!(env!("OUT_DIR"), "/responses.rs"));
+
 const AFFECTIONATE_TERM_PLACEHOLDER: &str = "AFFECTIONATE_TERM";
 const MOMMYS_PRONOUN_PLACEHOLDER: &str = "MOMMYS_PRONOUN";
 const MOMMYS_ROLE_PLACEHOLDER: &str = "MOMMYS_ROLE";
@@ -15,12 +15,6 @@ const MOMMYS_ROLES_ENV_VAR: &str = "CARGO_MOMMYS_ROLES";
 const AFFECTIONATE_TERMS_DEFAULT: &str = "girl";
 const MOMMYS_PRONOUNS_DEFAULT: &str = "her";
 const MOMMYS_ROLES_DEFAULT: &str = "mommy";
-
-#[derive(Deserialize)]
-struct Responses {
-    positive: Vec<String>,
-    negative: Vec<String>,
-}
 
 enum ResponseType {
     Positive,
@@ -65,11 +59,9 @@ fn select_response(response_type: ResponseType) -> String {
     let mommys_roles = parse_options(MOMMYS_ROLES_ENV_VAR, MOMMYS_ROLES_DEFAULT);
 
     // Choose what mommy will say~
-    let responses: Responses = serde_json::from_str(RESPONSES).expect("RESPONSES to be valid JSON");
-
     let response = match response_type {
-        ResponseType::Positive => &responses.positive,
-        ResponseType::Negative => &responses.negative,
+        ResponseType::Positive => &POSITIVE_RESPONSES,
+        ResponseType::Negative => &NEGATIVE_RESPONSES,
     }
     .choose(&mut rng)
     .expect("non-zero amount of responses");


### PR DESCRIPTION
well, i just made a `build.rs` file which parses `responses.json` and generates constant string slices.

thus the mommy got rid of the overhead of deserialization and began to have a slightly smaller size by removing the `serde` and `serde_json` dependencies~