### PR TITLE
Add features to not emit moods at build time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,13 @@ version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+# This affects if a given response is *supported* in the built binary,
+# not if it's enabled by default
+default = ["thirsty", "yikes"]
+
+thirsty = []
+yikes = []
 
 [dependencies]
 fastrand = "1.8.0"

--- a/build.rs
+++ b/build.rs
@@ -16,44 +16,44 @@ struct Responses {
     negative: Vec<String>,
 }
 
+fn serialise_responses(name: &str, response: Responses) -> String {
+    let response_positive = response.positive;
+    let response_negative = response.negative;
+
+    format!(
+        r#"("{name}", &[
+        &{response_positive:?},
+        &{response_negative:?},
+    ]),"#
+    )
+}
+
 fn main() {
     let out_dir = &env::var("OUT_DIR").unwrap();
     let AllResponses {
-        chill:
-            Responses {
-                positive: chill_positive,
-                negative: chill_negative,
-            },
-        thirsty:
-            Responses {
-                positive: thirsty_positive,
-                negative: thirsty_negative,
-            },
-        yikes:
-            Responses {
-                positive: yikes_positive,
-                negative: yikes_negative,
-            },
+        chill,
+        thirsty,
+        yikes,
     } = serde_json::from_str(RESPONSES).unwrap();
     let dest_path = Path::new(out_dir).join("responses.rs");
+
+    let mut enabled_responses = String::new();
+
+    enabled_responses += &serialise_responses("chill", chill);
+
+    if cfg!(feature = "thirsty") {
+        enabled_responses += &serialise_responses("thirsty", thirsty);
+    }
+    if cfg!(feature = "yikes") {
+        enabled_responses += &serialise_responses("yikes", yikes);
+    }
 
     fs::write(
         dest_path,
         format!(
             r#"const RESPONSES: &[(&str, &[&[&str]])] = &[
-    ("chill", &[
-        &{chill_positive:?},
-        &{chill_negative:?},
-    ]),
-    ("thirsty", &[
-        &{thirsty_positive:?},
-        &{thirsty_negative:?},
-    ]),
-    ("yikes", &[
-        &{yikes_positive:?},
-        &{yikes_negative:?},
-    ]),
-];"#
+                {enabled_responses}
+            ];"#
         ),
     )
     .unwrap();


### PR DESCRIPTION
Fixes: #30

Tested that a default settings install has all moods, and enabling only the `thirsty` feature removes `slut` from the built binary (and enabling no features removes the thirsty strings, searching for `butt` checks that)