### PR TITLE
Non terminal output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::let_and_return)]
 
 use fastrand::Rng;
+use std::io::IsTerminal;
 
 include!(concat!(env!("OUT_DIR"), "/responses.rs"));
 
@@ -41,9 +42,11 @@ fn real_main() -> Result<i32, Box<dyn std::error::Error>> {
         select_response(ResponseType::Negative)
     };
 
+    let stylize = std::io::stderr().is_terminal();
     match response {
-        Ok(resp) => eprintln!("\x1b[1m{}\x1b[0m", resp),
-        Err(resp) => eprintln!("\x1b[31m{}\x1b[0m", resp),
+        Ok(resp) if stylize => eprintln!("\x1b[1m{}\x1b[0m", resp),
+        Err(resp) if stylize => eprintln!("\x1b[31m{}\x1b[0m", resp),
+        Ok(resp) | Err(resp) => eprintln!("{}", resp),
     }
 
     Ok(code)

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,10 +43,10 @@ fn real_main() -> Result<i32, Box<dyn std::error::Error>> {
     };
 
     let stylize = std::io::stderr().is_terminal();
-    match response {
-        Ok(resp) if stylize => eprintln!("\x1b[1m{}\x1b[0m", resp),
-        Err(resp) if stylize => eprintln!("\x1b[31m{}\x1b[0m", resp),
-        Ok(resp) | Err(resp) => eprintln!("{}", resp),
+    match (response, stylize) {
+        (Ok(resp), true) => eprintln!("\x1b[1m{}\x1b[0m", resp),
+        (Err(resp), true) => eprintln!("\x1b[31m{}\x1b[0m", resp),
+        (Ok(resp) | Err(resp), false) => eprintln!("{}", resp),
     }
 
     Ok(code)


### PR DESCRIPTION
When I redirect cargo output to a file, mommy writes this:
```
[1mmommy loves you~ ❤️[0m
```

I fixed it in this PR~