### PR TITLE
mommy can now change her true nature for you~

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -98,7 +98,7 @@ fn main() {
         let defaults = &var.defaults;
         let _ = write!(
             vars,
-            r#"Var {{ env_key: "CARGO_MOMMYS_{env_key}", defaults: &{defaults:?} }},"#
+            r#"Var {{ env_key: "{env_key}", defaults: &{defaults:?} }},"#
         );
     }
 

--- a/responses.json
+++ b/responses.json
@@ -113,7 +113,7 @@
             "defaults": ["her"]
         },
         "role": {
-            "defaults": ["mommy"]
+            "defaults": []
         },
 
         "affectionate_term": {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ fn main() {
 }
 
 fn real_main() -> Result<i32, Box<dyn std::error::Error>> {
+    let rng = Rng::new();
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
     let mut arg_iter = std::env::args().peekable();
 
@@ -29,11 +30,14 @@ fn real_main() -> Result<i32, Box<dyn std::error::Error>> {
     // but we want to let it instead be cargo-daddy, and for everything to rekey itself to:
     // * make the default role be "daddy"
     // * make all the read env-vars be "CARGO_DADDYS_*"
-    let first_arg = arg_iter.next().unwrap_or_default();
-    let first_arg = first_arg
-        .strip_suffix(".exe")
-        .unwrap_or(&first_arg)
-        .to_owned();
+    let mut platform_uses_exe = false;
+    let raw_first_arg = arg_iter.next().unwrap_or_default();
+    let first_arg = if let Some(stripped) = raw_first_arg.strip_suffix(".exe") {
+        platform_uses_exe = true;
+        stripped.to_owned()
+    } else {
+        raw_first_arg.clone()
+    };
     let true_role = if let Some((_path, role)) = first_arg.rsplit_once("cargo-") {
         role.to_owned()
     } else {
@@ -52,17 +56,70 @@ fn real_main() -> Result<i32, Box<dyn std::error::Error>> {
     // if we don't do this, we'll infinitely recurse into ourselves by re-calling "cargo mommy"!
     // (note that it *is* supported to do `cargo mommy mommy` and get two messages, although I
     // belive we do this, `cargo-mommy mommy` will still only get you onw message).
-    //
-    // ...
-    //
-    // ~
+
     if arg_iter.peek().map_or(false, |arg| arg == &true_role) {
         let _role = arg_iter.next();
     }
 
+    // *WHEEZES*
+    //
+    // *PANTS FOR A MINUTE*
+    //
+    // Ok so now we want to detect if the invocation looked like "cargo mommy i mean daddy"
+    // if it *does* we want to copy ourselves to rename cargo-mommy to cargo-daddy. We can't
+    // clone std::env::args() and we need to peek more than one element, so we create a
+    // "speculation" buffer that we will chain back into the args on failed speculation.
+    // on successful speculation we'll purge the buffer, effectively consuming the args.
+    //
+    // ...
+    //
+    // ~
+    let mut speculated = vec![];
+    {
+        speculated.extend(arg_iter.by_ref().take(3));
+        let new_role = speculated.get(2);
+        let mean = speculated.get(1) == Some(&"mean".to_owned());
+        let i = speculated.get(0) == Some(&"i".to_owned());
+        if i && mean {
+            if let Some(new_role) = new_role.cloned() {
+                // Ok at this point we're confident we got "i mean <new_role>"
+                // so definitely consume the arguments~
+                speculated.clear();
+
+                // If the new role is the same as before, they typed something like
+                // "cargo mommy i mean mommy test" so we don't need to do anything~
+                if new_role != true_role {
+                    let orig_bin_path = std::path::PathBuf::from(raw_first_arg);
+                    if let Some(parent) = orig_bin_path.parent() {
+                        let new_bin_ext = if platform_uses_exe { ".exe" } else { "" };
+                        let new_bin_name = format!("cargo-{new_role}{new_bin_ext}");
+                        let new_bin_path = parent.join(new_bin_name);
+                        if let Err(e) = std::fs::copy(orig_bin_path, new_bin_path) {
+                            return Err(format!(
+                                "{role} couldn't copy {pronoun}self...\n{e:?}",
+                                role = ROLE.load(&true_role, &rng)?,
+                                pronoun = PRONOUN.load(&true_role, &rng)?,
+                            ))?;
+                        } else {
+                            // Just exit immediately on success, don't try to get too clever here~
+                            eprintln!("{true_role} is now {new_role}~");
+                            return Ok(0);
+                        }
+                    } else {
+                        return Err(format!(
+                            "{role} couldn't copy {pronoun}self...\n(couldn't find own parent dir)",
+                            role = ROLE.load(&true_role, &rng)?,
+                            pronoun = PRONOUN.load(&true_role, &rng)?,
+                        ))?;
+                    }
+                }
+            }
+        }
+    }
+
     // Time for mommy to call cargo~
     let mut cmd = std::process::Command::new(cargo);
-    cmd.args(arg_iter);
+    cmd.args(speculated.into_iter().chain(arg_iter));
     let status = cmd.status()?;
     let code = status.code().unwrap_or(-1);
     if is_quiet_mode_enabled(cmd.get_args()) {
@@ -71,9 +128,9 @@ fn real_main() -> Result<i32, Box<dyn std::error::Error>> {
 
     // Time for mommy to tell you how you did~
     let response = if status.success() {
-        select_response(&true_role, ResponseType::Positive)
+        select_response(&true_role, &rng, ResponseType::Positive)
     } else {
-        select_response(&true_role, ResponseType::Negative)
+        select_response(&true_role, &rng, ResponseType::Negative)
     };
 
     match response {
@@ -98,13 +155,13 @@ fn is_quiet_mode_enabled(args: std::process::CommandArgs) -> bool {
     false
 }
 
-fn select_response(true_role: &str, response_type: ResponseType) -> Result<String, String> {
-    let rng = Rng::new();
-
-    // Get mommy's options~
-
+fn select_response(
+    true_role: &str,
+    rng: &Rng,
+    response_type: ResponseType,
+) -> Result<String, String> {
     // Choose what mood mommy is in~
-    let mood = MOOD.load(true_role, &rng)?;
+    let mood = MOOD.load(true_role, rng)?;
 
     let Some(group) = &CONFIG.moods.iter().find(|group| group.name == mood) else {
         let supported_moods_str = CONFIG
@@ -115,8 +172,8 @@ fn select_response(true_role: &str, response_type: ResponseType) -> Result<Strin
             .join(", ");
         return Err(format!(
             "{role} doesn't know how to feel {mood}... {pronoun} moods are {supported_moods_str}",
-            role = ROLE.load(true_role, &rng)?,
-            pronoun = PRONOUN.load(true_role, &rng)?,
+            role = ROLE.load(true_role, rng)?,
+            pronoun = PRONOUN.load(true_role, rng)?,
         ));
     };
 
@@ -128,12 +185,12 @@ fn select_response(true_role: &str, response_type: ResponseType) -> Result<Strin
     let response = &responses[rng.usize(..responses.len())];
 
     // Apply options to the message template~
-    let mut response = CONFIG.apply_template(true_role, response, &rng)?;
+    let mut response = CONFIG.apply_template(true_role, response, rng)?;
 
     // Let mommy show a little emote~
     let should_emote = rng.bool();
     if should_emote {
-        if let Ok(emote) = EMOTE.load(true_role, &rng) {
+        if let Ok(emote) = EMOTE.load(true_role, rng) {
             response.push(' ');
             response.push_str(&emote);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,11 +20,47 @@ fn main() {
 fn real_main() -> Result<i32, Box<dyn std::error::Error>> {
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
     let mut arg_iter = std::env::args().peekable();
-    let _cargo = arg_iter.next();
-    if arg_iter.peek().map_or(false, |arg| arg == "mommy") {
-        let _mommy = arg_iter.next();
+
+    // Understand who mommy really is~
+    //
+    // *INHALES*
+    //
+    // Ok so first argument is this binary, should look like /some/path/to/cargo-mommy(.exe)
+    // but we want to let it instead be cargo-daddy, and for everything to rekey itself to:
+    // * make the default role be "daddy"
+    // * make all the read env-vars be "CARGO_DADDYS_*"
+    let first_arg = arg_iter.next().unwrap_or_default();
+    let first_arg = first_arg
+        .strip_suffix(".exe")
+        .unwrap_or(&first_arg)
+        .to_owned();
+    let true_role = if let Some((_path, role)) = first_arg.rsplit_once("cargo-") {
+        role.to_owned()
+    } else {
+        // If something messed up is going on, default to "mommy"
+        "mommy".to_owned()
+    };
+
+    // *GASPS FOR BREATH*
+    //
+    // *INHALES DESPERATELY*
+    //
+    // cargo subcommands when run as "cargo blah" get the "blah" argument passed to themselves
+    // as the *second* argument. However if we are invoked directly as "cargo-blah" we won't
+    // have that extra argument! So if there's a second argument that is "mommy" (or whatever)
+    // we pop off that redundant copy before forwarding the rest of the args back to "cargo ...".
+    // if we don't do this, we'll infinitely recurse into ourselves by re-calling "cargo mommy"!
+    // (note that it *is* supported to do `cargo mommy mommy` and get two messages, although I
+    // belive we do this, `cargo-mommy mommy` will still only get you onw message).
+    //
+    // ...
+    //
+    // ~
+    if arg_iter.peek().map_or(false, |arg| arg == &true_role) {
+        let _role = arg_iter.next();
     }
 
+    // Time for mommy to call cargo~
     let mut cmd = std::process::Command::new(cargo);
     cmd.args(arg_iter);
     let status = cmd.status()?;
@@ -33,10 +69,11 @@ fn real_main() -> Result<i32, Box<dyn std::error::Error>> {
         return Ok(code);
     }
 
+    // Time for mommy to tell you how you did~
     let response = if status.success() {
-        select_response(ResponseType::Positive)
+        select_response(&true_role, ResponseType::Positive)
     } else {
-        select_response(ResponseType::Negative)
+        select_response(&true_role, ResponseType::Negative)
     };
 
     match response {
@@ -61,19 +98,15 @@ fn is_quiet_mode_enabled(args: std::process::CommandArgs) -> bool {
     false
 }
 
-fn select_response(response_type: ResponseType) -> Result<String, String> {
+fn select_response(true_role: &str, response_type: ResponseType) -> Result<String, String> {
     let rng = Rng::new();
 
     // Get mommy's options~
 
     // Choose what mood mommy is in~
-    let mood = MOOD.load(&rng)?;
+    let mood = MOOD.load(true_role, &rng)?;
 
-    let Some(group) = &CONFIG
-        .moods
-        .iter()
-        .find(|group| group.name == mood)
-    else {
+    let Some(group) = &CONFIG.moods.iter().find(|group| group.name == mood) else {
         let supported_moods_str = CONFIG
             .moods
             .iter()
@@ -82,8 +115,8 @@ fn select_response(response_type: ResponseType) -> Result<String, String> {
             .join(", ");
         return Err(format!(
             "{role} doesn't know how to feel {mood}... {pronoun} moods are {supported_moods_str}",
-            role = ROLE.load(&rng)?,
-            pronoun = PRONOUN.load(&rng)?,
+            role = ROLE.load(true_role, &rng)?,
+            pronoun = PRONOUN.load(true_role, &rng)?,
         ));
     };
 
@@ -95,12 +128,12 @@ fn select_response(response_type: ResponseType) -> Result<String, String> {
     let response = &responses[rng.usize(..responses.len())];
 
     // Apply options to the message template~
-    let mut response = CONFIG.apply_template(response, &rng)?;
+    let mut response = CONFIG.apply_template(true_role, response, &rng)?;
 
     // Let mommy show a little emote~
     let should_emote = rng.bool();
     if should_emote {
-        if let Ok(emote) = EMOTE.load(&rng) {
+        if let Ok(emote) = EMOTE.load(true_role, &rng) {
             response.push(' ');
             response.push_str(&emote);
         }
@@ -120,12 +153,17 @@ struct Config<'a> {
 
 impl Config<'_> {
     /// Applies a template by resolving `Chunk::Var`s against `self.vars`.
-    fn apply_template(&self, chunks: &[Chunk], rng: &Rng) -> Result<String, String> {
+    fn apply_template(
+        &self,
+        true_role: &str,
+        chunks: &[Chunk],
+        rng: &Rng,
+    ) -> Result<String, String> {
         let mut out = String::new();
         for chunk in chunks {
             match chunk {
                 Chunk::Text(text) => out.push_str(text),
-                Chunk::Var(i) => out.push_str(&self.vars[*i].load(rng)?),
+                Chunk::Var(i) => out.push_str(&self.vars[*i].load(true_role, rng)?),
             }
         }
         Ok(out)
@@ -154,10 +192,12 @@ struct Var<'a> {
 impl Var<'_> {
     /// Loads this variable and selects one of the possible values for it;
     /// produces an in-character error message on failure.
-    fn load(&self, rng: &Rng) -> Result<String, String> {
-        let var = std::env::var(self.env_key);
+    fn load(&self, true_role: &str, rng: &Rng) -> Result<String, String> {
+        // try to load custom settings from env vars~
+        let var = std::env::var(self.env(true_role));
         let split;
 
+        // parse the custom settings or use the builtins~
         let choices = match var.as_deref() {
             Ok("") => &[],
             Ok(value) => {
@@ -168,20 +208,31 @@ impl Var<'_> {
         };
 
         if choices.is_empty() {
-            // If self == ROLE, mommy needs to avoid infinite recursion and
-            // blowing her stack~
-            let role = match self.env_key {
-                "CARGO_MOMMYS_ROLES" => "mommy(?)".to_string(),
-                _ => ROLE.load(rng)?,
-            };
+            // If there's no ROLES set, default to mommy's true nature~
+            if self.env_key == "ROLES" {
+                return Ok(true_role.to_owned());
+            }
 
+            // Otherwise, report an error~
+            let role = ROLE.load(true_role, rng)?;
             return Err(format!(
                 "{role} needs at least one value for {}~",
                 self.env_key
             ));
         }
 
+        // now select a choice from the options~
         Ok(choices[rng.usize(..choices.len())].to_owned())
+    }
+
+    /// Gets the name of the env var to load~
+    fn env(&self, true_role: &str) -> String {
+        // Normally we'd load from CARGO_MOMMYS_*
+        // but if cargo-mommy is cargo-daddy, we should load CARGO_DADDYS_* instead~
+        let screaming_role = true_role.to_ascii_uppercase();
+        let var = format!("CARGO_{screaming_role}S_{}", self.env_key);
+        eprintln!("using: {}", var);
+        var
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,9 +287,7 @@ impl Var<'_> {
         // Normally we'd load from CARGO_MOMMYS_*
         // but if cargo-mommy is cargo-daddy, we should load CARGO_DADDYS_* instead~
         let screaming_role = true_role.to_ascii_uppercase();
-        let var = format!("CARGO_{screaming_role}S_{}", self.env_key);
-        eprintln!("using: {}", var);
-        var
+        format!("CARGO_{screaming_role}S_{}", self.env_key)
     }
 }
 


### PR DESCRIPTION
This adds the ability to say "cargo mommy i mean daddy" ("daddy" here is an arbitrary value), which makes cargo-mommy copy itself to a new binary called cargo-daddy. As a result of how `cargo <subcommand> ...` works, this makes `cargo daddy ...` now resolve.

It also changes cargo-mommy to determine it's "true role" from the name of its binary. So in the above case, `cargo daddy` would detect its "true role" is "daddy". This makes the default role be "daddy" (was "mommy") and it renames all the env-vars we'd query from `CARGO_MOMMYS_*` to `CARGO_DADDYS_*`.

Also as a bonus `cargo mommy i mean mommy test` just runs `cargo mommy test`

mommy's happy to change her true nature for you~