### PR TITLE
mommy now converts a role with spaces to a nice environment variable name~

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -295,7 +295,8 @@ impl Var<'_> {
     fn env(&self, true_role: &str) -> String {
         // Normally we'd load from CARGO_MOMMYS_*
         // but if cargo-mommy is cargo-daddy, we should load CARGO_DADDYS_* instead~
-        let screaming_role = true_role.to_ascii_uppercase();
+        // If we have multiple words in our role, we must also be careful with spaces~
+        let screaming_role = true_role.to_ascii_uppercase().replace(' ', "_");
         format!("CARGO_{screaming_role}S_{}", self.env_key)
     }
 }


### PR DESCRIPTION
Previously, role conversion to `screaming_role` (in order to fetch environment variables) did not account for the fact that you can have spaces in the role (I will let you use your imagination to figure out examples). A better behaviour would be to convert spaces to underscores.

This behaviour should also be documented, but I see no documentation on the "i mean" feature yet so I will let whoever does that change bundle the documentation for this change in with everything else.

---

This is intended to fix #51 .